### PR TITLE
fix: missing string import

### DIFF
--- a/dhcpwn.py
+++ b/dhcpwn.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import string
 
 # Quiet scapy
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scapy-python3
+netifaces


### PR DESCRIPTION
```
./dhcpwn.py --interface wlan0 flood --count 256
Traceback (most recent call last):
  File "dhcpwn.py", line 74, in <module>
    main()
  File "dhcpwn.py", line 71, in main
    dispatch[args.command](**vars(args))
  File "dhcpwn.py", line 15, in dhcp_flood
    unique_hexdigits = str.encode("".join(set(string.hexdigits.lower())))
NameError: name 'string' is not defined
```
